### PR TITLE
Allow to overwrite the default tenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Bleib's behaviour is configured via the environment:
 | BLEIB_CHECK_MIGRATIONS_INTERVAL | 5                   | Seconds to wait between migration readiness checks                                                                       |
 | BLEIB_DATABASE_YML_PATH         | config/database.yml | Path to database.yml. Bleib needs this to perform database readiness checks without booting the whole rails environment. |
 | BLEIB_LOG_LEVEL                 | info                | Set this to `debug` to investigate why bleib is hanging.                                                                 |
+| BLEIB_DEFAULT_TENANT            | public              | Name of well-known always existing Tenant. This depends on the strategy you use with Apartment and your RDBMS. |
 
 # Caveats
 

--- a/lib/bleib/migrations.rb
+++ b/lib/bleib/migrations.rb
@@ -55,7 +55,7 @@ module Bleib
 
     def in_all_tenant_contexts
       tenants = []
-      tenants << ENV.fetch('RAILS_DEFAULT_TENANT', 'public')
+      tenants << ENV.fetch('BLEIB_DEFAULT_TENANT', 'public')
       Apartment::Tenant.each { |tenant| tenants << tenant }
 
       tenants.each do |tenant|

--- a/lib/bleib/migrations.rb
+++ b/lib/bleib/migrations.rb
@@ -54,7 +54,8 @@ module Bleib
     end
 
     def in_all_tenant_contexts
-      tenants = ['public']
+      tenants = []
+      tenants << ENV.fetch('RAILS_DEFAULT_TENANT', 'public')
       Apartment::Tenant.each { |tenant| tenants << tenant }
 
       tenants.each do |tenant|


### PR DESCRIPTION
The predefined tenant `public` seems like a remainder of being built for postgresql first. Apartment, when used with postgresql often uses DB-Schemas to organize the tenants. Since the default-schema in postgresql is called `public`, it made sense to prefill the list of tenants with this string. Apartment when used with mysql results in multiple databases and does not have a easy-to-guess default tenant.

In order to allow configuration of unusual DB, I introduced another ENV-var. When reading it, I default to `public` to not break the existing assumptions.