### PR TITLE
Initialize env at startup to get everything right

### DIFF
--- a/lib/tasks/bleib.rake
+++ b/lib/tasks/bleib.rake
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 namespace :bleib do
   desc 'Waits for database access'
-  task :wait_for_database do
+  task wait_for_database: :environment do
     configuration = Bleib::Configuration.from_environment
     Bleib::Database.new(configuration).wait_for_connection
   end
 
   desc 'Waits for database access and migrations'
-  task wait_for_migrations: [:wait_for_database, :environment] do
+  task wait_for_migrations: :wait_for_database do
     configuration = Bleib::Configuration.from_environment
 
     Bleib::Migrations.new(configuration).wait_until_done


### PR DESCRIPTION
Ros-Apartment frikelt an der `connection` Methode von Rails herum. Wenn wir darauf zugreifen, bevor Rails initialisiert ist, gibts bei weiteren Zugriffen (wait_for_migrations) eine Exception. Mit dem direkten laden des environments könnte dies behoben werden.

Siehe rails-on-services/apartment#92