### PR TITLE
Support wagons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 With bleib, your Rails application gains two new rake tasks:
 
-* `wait_for_database` - waits until the database is running and the configured user can access it
-* `wait_for_migrations` - performs `wait_for_database`, then waits until all migrations are up
+* `bleib:wait_for_database` - waits until the database is running and the configured user can access it
+* `bleib:wait_for_migrations` - performs `bleib:wait_for_database`, then waits until all migrations are up
 
 Bleib knows about the [Apartment gem](https://github.com/influitive/apartment) - if your project
 includes it, it will also check migrations on tenants. Likewise, it knows about the
@@ -13,9 +13,9 @@ includes it, it will also check migrations on tenants. Likewise, it knows about 
 
 This was built to be used in kubernetes/OpenShift deployments without a zero downtime approach.
 
-It allows you to `kubectl apply` your multi-Rails-pod configuration and delegate migrations to either 
-a `Job` or one of the `Pod`s. 
-Using bleib `initContainer`s, dependent Rails `Pod`s (say job workers or multiple replicas) can wait 
+It allows you to `kubectl apply` your multi-Rails-pod configuration and delegate migrations to either
+a `Job` or one of the `Pod`s.
+Using bleib `initContainer`s, dependent Rails `Pod`s (say job workers or multiple replicas) can wait
 for migrations or DB redeployments to finish.
 
 ## How to
@@ -23,7 +23,9 @@ for migrations or DB redeployments to finish.
 * Add the gem to your application: `gem 'bleib'`
 * Build your application image.
 * Add an `initContainer` that's based on your application image to your application `Pod`.
-* Set the command of the `initContainer` to `rake wait_for_migrations`.
+* Set the command of the `initContainer` to `rake bleib:wait_for_migrations`.
+* Add some way to migrate the database so that the waiting actually pays off at some point.
+* The migrations can be run after `rake bleib:wait_for_database` sees a connection.
 
 ### Configuration
 
@@ -39,7 +41,7 @@ Bleib's behaviour is configured via the environment:
 
 ## Caveats
 
-* Handles the `postresql`, `postgis` and `mysql2` database adapters.
+* Handles the `postgresql`, `postgis` and `mysql2` database adapters.
   It's simple to add further adapters, see `Bleib::Database#database_down_exception?` and `Bleib::Configuration#check!`
 
 ## Testing
@@ -48,3 +50,12 @@ Done by hand so far.
 
 If I had a magic wand, I'd do integration tests of `Bleib::Database` and `Bleib::Migrations` against
 a database container in various states (up, down, preloaded with dumps of different migration states).
+
+## ToDo (patches welcome)
+
+- [ ] add a basic rspec skeleton
+- [ ] add (mocked) specs for `Bleib::Migrations`
+- [ ] add (mocked) specs for `Bleib::Database`
+- [ ] add integration test for `Bleib::Database`
+- [ ] add integration test for `Bleib::Migrations`
+- [ ] add specs for `Bleib::Configuration`

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ With bleib, your Rails application gains two new rake tasks:
 * `wait_for_database` - waits until the database is running and the configured user can access it
 * `wait_for_migrations` - performs `wait_for_database`, then waits until all migrations are up
 
-Bleib knows about the [Apartment gem](https://github.com/influitive/apartment) - if your project 
-includes it, it will also check migrations on tenants.
+Bleib knows about the [Apartment gem](https://github.com/influitive/apartment) - if your project
+includes it, it will also check migrations on tenants. Likewise, it knows about the
+[Wagons gem](https://github.com/puzzle/wagons) and checks for migrations in all known wagons.
 
 This was built to be used in kubernetes/OpenShift deployments without a zero downtime approach.
 

--- a/bleib.gemspec
+++ b/bleib.gemspec
@@ -3,7 +3,7 @@ require_relative 'lib/bleib/version'
 Gem::Specification.new do |s|
   s.name        = 'bleib'
   s.version     = Bleib::VERSION
-  s.date        = '2018-10-04'
+  s.date        = '2024-09-18'
   s.summary     = 'Use a rake task to wait on database and migrations.'
   s.description = 'Intended for use in containerized setups where ' \
                   'another component takes care of migrating the database.'

--- a/lib/bleib/migrations.rb
+++ b/lib/bleib/migrations.rb
@@ -53,14 +53,12 @@ module Bleib
       ActiveRecord::Migration.check_pending!
     end
 
-    def in_all_tenant_contexts
+    def in_all_tenant_contexts(&block)
       tenants = [ENV.fetch('BLEIB_DEFAULT_TENANT', 'public')] +
                 Apartment.tenant_names
 
       tenants.uniq.each do |tenant|
-        Apartment::Tenant.switch(tenant) do
-          yield
-        end
+        Apartment::Tenant.switch(tenant, &block)
       end
     end
 

--- a/lib/bleib/version.rb
+++ b/lib/bleib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bleib
-  VERSION = '0.0.13'
+  VERSION = '0.0.14'
 end


### PR DESCRIPTION
The code to check the wagons for migration is inspired by the rake-tasks of the wagons-gem. It is stripped down as only a fraction of the functionality is needed.

Aside from this addition, the documentation has been extended.